### PR TITLE
Add perl 5.40

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         runner: [ubuntu-latest, macos-latest] #, windows-latest]
-        perl: [ '5.30', '5.36' ]
+        perl: [ '5.30', '5.36', '5.40' ]
         exclude:
           - runner: windows-latest
             perl: '5.36'


### PR DESCRIPTION
I was assigned this repo by the [Pull request Club](https://pullrequest.club). This rather minimal change is to add perl version 5.40 to the list of tested perls.